### PR TITLE
Roll out partial support for disappearing messages

### DIFF
--- a/logincoming.py
+++ b/logincoming.py
@@ -7,10 +7,9 @@ import sqlite3
 import time
 import shlex
 import shutil
-import yaml
 
-import magic
 import pydbus
+import yaml
 
 import loadsignal
 
@@ -41,9 +40,11 @@ class SignalMessage:
         else:
             self.attachments = None
 
-        if type(self.timestamp) == int:
-            self.timestamp = datetime.utcfromtimestamp(
-                    math.floor(self.timestamp/1000))
+        if type(self.timestamp) == int and len(str(self.timestamp)) > 10:
+            self.timestamp = math.floor(self.timestamp/1000)
+ 
+        self.localtime = datetime.fromtimestamp(self.timestamp).isoformat(
+                                            sep=' ', timespec='seconds')
 
     def log_to_db(self, conn):
         conn.execute("""insert or replace into messages(

--- a/logincoming.py
+++ b/logincoming.py
@@ -58,7 +58,9 @@ def create_database():
                     groupID     text,
                     message     text,
                     attachments text,
-                    timestamp   timestamp);"""
+                    timestamp   timestamp,
+                    expires_in  integer,
+                    seen_at     timestamp);"""
     conn.executescript(schema_script)
     conn.commit()
     conn.close()

--- a/logincoming.py
+++ b/logincoming.py
@@ -54,6 +54,25 @@ class SignalMessage:
                          self.message, self.attachments, self.timestamp,
                          self.expires_in, self.seen_at))
 
+    def get_expiration_timestamp(self):
+        if self.seen_at and self.expires_in:
+            self.expiration_timestamp = self.seen_at + self.expires_in
+        else:
+            self.expiration_timestamp = False
+
+        return self.expiration_timestamp
+
+    def is_expired(self):
+        if (self.get_expiration_timestamp() and 
+                datetime.fromtimestamp(self.expiration_timestamp) 
+                < datetime.now()):
+            expired = True
+        else:
+            expired = False
+
+        return expired
+
+
 def create_database():
     conn = sqlite3.connect(database)
     schema_script = """create table messages (

--- a/logincoming.py
+++ b/logincoming.py
@@ -26,13 +26,14 @@ sitepath = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'static')
 
 class SignalMessage:
     def __init__(self, timestamp, source, recipient, groupID, message, 
-                 attachments, expires_in=None, rowid=None):
+                 attachments, expires_in=None, seen_at=None, rowid=None):
         self.timestamp = timestamp
         self.source = source
         self.recipient = recipient
         self.groupID = groupID
         self.message = message
         self.expires_in = expires_in
+        self.seen_at = seen_at
         self.rowid = rowid
 
         if attachments:
@@ -41,15 +42,16 @@ class SignalMessage:
             self.attachments = None
 
         if type(self.timestamp) == int:
-            self.timestamp = datetime.utcfromtimestamp(math.floor(self.timestamp/1000))
+            self.timestamp = datetime.utcfromtimestamp(
+                    math.floor(self.timestamp/1000))
 
     def log_to_db(self, conn):
-        conn.execute("""insert into messages(
-                            source, recipient, message, attachments,
-                            timestamp, expires_in)
-                            values (?, ?, ?, ?, ?, ?)""",
-                     (self.source, self.recipient, self.message, 
-                         self.attachments, self.timestamp, self.expires_in))
+        conn.execute("""insert or replace into messages(
+                            rowid, source, recipient, message, attachments,                                   timestamp, expires_in, seen_at)
+                            values (?, ?, ?, ?, ?, ?, ?, ?)""",
+                     (self.rowid, self.source, self.recipient, 
+                         self.message, self.attachments, self.timestamp,
+                         self.expires_in, self.seen_at))
 
 def create_database():
     conn = sqlite3.connect(database)

--- a/readlog.py
+++ b/readlog.py
@@ -10,6 +10,7 @@ from datetime import datetime
 from dominate.tags import *
 from dominate.util import raw
 from logincoming import SignalMessage
+import deletemsg
 
 from settings import NUMBER, database
 
@@ -94,6 +95,10 @@ def main():
 
         with thread.add(ul()):
             for msg in msgs:
+                if msg.is_expired():
+                    deletemsg.single_msg(msg.rowid)
+                    continue
+                
                 if msg.source == num:
                     msg_text = msg.message
                     msg_class = 'tip'
@@ -114,7 +119,7 @@ def main():
                 disappearing_indicator = ' ⌛&#xFE0E'
 
                 if msg.expires_in:
-                    exp_timestamp = msg.seen_at + msg.expires_in
+                    exp_timestamp = msg.get_expiration_timestamp()
                     exp_time = datetime.fromtimestamp(exp_timestamp).isoformat(
                             sep=' ', timespec='seconds')
                     exp_remaining = exp_timestamp - int(


### PR DESCRIPTION
This addresses #5, but with a few limitations that I'll enumerate in that issue. In order to get this working (and for the sake of general robustness), I changed the data storage format for all dates to UNIX timestamps. I've also introduced the concept of `seen_at` for incoming messages, which could be used for a "new messages" indicator.